### PR TITLE
Real parsing + MCA offers: ID wiring, spinner fix, fallback toast

### DIFF
--- a/server/routes/statements.py
+++ b/server/routes/statements.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 from typing import Any, Dict
 from fastapi import APIRouter, Depends, HTTPException, Request, Query
+import pathlib
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
 from core.database import get_db
 from core.idempotency import capture_body, require_idempotency, store_idempotent
 from core.auth import require_bearer
-from models import MetricsSnapshot
+from models import MetricsSnapshot, Document
+from services.bank_analysis import BankStatementAnalyzer
 
 router = APIRouter(prefix="/api/statements", tags=["statements"], dependencies=[Depends(require_bearer)])
 
@@ -33,9 +35,54 @@ async def parse_statements(
         .order_by(desc(MetricsSnapshot.created_at))
         .first()
     )
-    if not row or not getattr(row, "payload", None):
-        raise HTTPException(404, "No metrics available for this deal. Upload 3 statements first.")
 
-    resp = {"ok": True, "metrics": row.payload}
+    if row and getattr(row, "payload", None):
+        resp = {"ok": True, "metrics": row.payload}
+        await store_idempotent(request, resp)
+        return resp
+
+    documents = (
+        db.query(Document)
+        .filter(Document.deal_id == deal_id)
+        .order_by(Document.created_at.asc())
+        .all()
+    )
+
+    if not documents:
+        raise HTTPException(404, "No bank statements found for this deal. Upload 3 statements first.")
+
+    file_contents = []
+    filenames = []
+    for doc in documents:
+        if doc.file_data:
+            file_contents.append(bytes(doc.file_data))
+            filenames.append(doc.filename or f"statement-{len(file_contents)}.pdf")
+            continue
+
+        if not doc.storage_key:
+            raise HTTPException(500, f"Document {doc.id} is missing stored content")
+
+        path = pathlib.Path(doc.storage_key)
+        if not path.exists():
+            raise HTTPException(500, f"Stored document {path} not found on disk")
+
+        try:
+            file_contents.append(path.read_bytes())
+            filenames.append(doc.filename or path.name)
+        except Exception as exc:
+            raise HTTPException(500, f"Unable to read document {doc.filename or doc.id}: {exc}")
+
+    analyzer = BankStatementAnalyzer()
+
+    try:
+        metrics = analyzer.analyze_statements(file_contents, filenames)
+    except Exception as exc:
+        raise HTTPException(500, f"Failed to analyze bank statements: {exc}")
+
+    snapshot = MetricsSnapshot(deal_id=deal_id, source="statements", payload=metrics)
+    db.add(snapshot)
+    db.commit()
+
+    resp = {"ok": True, "metrics": metrics}
     await store_idempotent(request, resp)
     return resp

--- a/web/src/state/useAppStore.ts
+++ b/web/src/state/useAppStore.ts
@@ -3,6 +3,32 @@ import { persist } from 'zustand/middleware'
 import { Rule, Persona, Merchant, FieldId, RuleEngineResult, Template } from '../types'
 // Simplified state management without external dependencies
 
+const getEnvValue = (key: string): string | undefined => {
+  if (typeof window !== 'undefined') {
+    const win = window as any
+    if (win.ENV?.[key]) return win.ENV[key]
+    if (win[key]) return win[key]
+  }
+
+  try {
+    const meta = import.meta as any
+    if (meta?.env?.[key]) {
+      return meta.env[key]
+    }
+  } catch (error) {
+    // Ignore environments where import.meta is undefined
+  }
+
+  const globalAny = globalThis as any
+  if (globalAny?.ENV?.[key]) return globalAny.ENV[key]
+  if (globalAny?.[key]) return globalAny[key]
+
+  return undefined
+}
+
+const defaultBaseUrl = getEnvValue('VITE_API_BASE') || ''
+const defaultApiKey = getEnvValue('VITE_API_KEY') || ''
+
 export type ChatMessage = {
   id: string
   type: 'user' | 'bot'
@@ -80,8 +106,8 @@ export const useAppStore = create<AppState>()(
     (set, get) => ({
       // API Configuration - Use direct backend connection for Replit
       apiConfig: {
-        baseUrl: 'http://172.31.89.226:8000',  // Direct connection to backend on internal network
-        apiKey: (typeof window !== 'undefined' && (window as any).ENV?.VITE_API_KEY) || '',
+        baseUrl: defaultBaseUrl,
+        apiKey: defaultApiKey,
         idempotencyEnabled: true
       },
       setApiConfig: (config) => set((state) => ({


### PR DESCRIPTION
## What’s in this PR
- Wire real merchant/deal flow (no more demo IDs)
- Turn on real statement parsing (pdfplumber + OpenAI) if OPENAI_API_KEY is set
- Fix infinite spinner (double-base-URL) on /api/statements/parse
- Default frontend baseUrl to same-origin; allow override via VITE_API_BASE
- Add a toast when parsing falls back to demo metrics

### Changed files
- server/routes/merchants.py
- web/src/lib/api.ts
- web/src/state/useAppStore.ts
- web/src/pages/OffersLab.tsx

### Deployment Notes
- Set `OPENAI_API_KEY` in backend environment to enable GPT-enhanced parsing.
- Frontend can run same-origin, or set `VITE_API_BASE` to point to backend.

### QA checklist
- [ ] Auto-create merchant (if none), start deal, upload 3 PDFs
- [ ] Metrics appear from `/api/statements/parse`
- [ ] Offers appear via `/api/offers/simple`
- [ ] Remove OPENAI_API_KEY → fallback metrics + toast appear

------
https://chatgpt.com/codex/tasks/task_e_68ced10a28c08328904513482e0e2b86