### PR TITLE
Real parsing + MCA offers: ID wiring, spinner fix, fallback toast

### DIFF
--- a/web/src/state/useAppStore.ts
+++ b/web/src/state/useAppStore.ts
@@ -3,6 +3,13 @@ import { persist } from 'zustand/middleware'
 import { Rule, Persona, Merchant, FieldId, RuleEngineResult, Template } from '../types'
 // Simplified state management without external dependencies
 
+const runtimeEnv = (typeof window !== 'undefined' ? ((window as any).ENV ?? {}) : {}) as Record<string, string>
+const buildEnv = ((import.meta as any)?.env ?? {}) as Record<string, string>
+
+const defaultApiBase = runtimeEnv.VITE_API_BASE ?? buildEnv.VITE_API_BASE ?? ''
+const defaultApiKey = runtimeEnv.VITE_API_KEY ?? buildEnv.VITE_API_KEY ?? ''
+const defaultTenantId = runtimeEnv.VITE_TENANT_ID ?? buildEnv.VITE_TENANT_ID ?? 'demo'
+
 export type ChatMessage = {
   id: string
   type: 'user' | 'bot'
@@ -15,6 +22,7 @@ export type ApiConfig = {
   baseUrl: string
   apiKey?: string
   idempotencyEnabled: boolean
+  tenantId?: string
 }
 
 export type IntakeStep = {
@@ -80,8 +88,9 @@ export const useAppStore = create<AppState>()(
     (set, get) => ({
       // API Configuration - Use direct backend connection for Replit
       apiConfig: {
-        baseUrl: 'http://172.31.89.226:8000',  // Direct connection to backend on internal network
-        apiKey: (typeof window !== 'undefined' && (window as any).ENV?.VITE_API_KEY) || '',
+        baseUrl: defaultApiBase,
+        apiKey: defaultApiKey,
+        tenantId: defaultTenantId,
         idempotencyEnabled: true
       },
       setApiConfig: (config) => set((state) => ({


### PR DESCRIPTION
## What’s in this PR
- Wire real merchant/deal flow (no more demo IDs)
- Turn on real statement parsing (pdfplumber + OpenAI) if OPENAI_API_KEY is set
- Fix infinite spinner (double-base-URL) on /api/statements/parse
- Default frontend baseUrl to same-origin; allow override via VITE_API_BASE
- Add a toast when parsing falls back to demo metrics

### Changed files
- server/routes/merchants.py
- web/src/lib/api.ts
- web/src/state/useAppStore.ts
- web/src/pages/OffersLab.tsx

### Deployment Notes
- Set `OPENAI_API_KEY` in backend environment to enable GPT-enhanced parsing.
- Frontend can run same-origin, or set `VITE_API_BASE` to point to backend.

### QA checklist
- [ ] Auto-create merchant (if none), start deal, upload 3 PDFs
- [ ] Metrics appear from `/api/statements/parse`
- [ ] Offers appear via `/api/offers/simple`
- [ ] Remove OPENAI_API_KEY → fallback metrics + toast appear

------
https://chatgpt.com/codex/tasks/task_e_68ced10a28c08328904513482e0e2b86